### PR TITLE
fix: print blank line after every formula to `OutputHandle`, rather than always print to stdout

### DIFF
--- a/tptp4X.c
+++ b/tptp4X.c
@@ -322,7 +322,7 @@ SyntaxType * LastNodeType) {
  *LastNodeType == tptp_fof || *LastNodeType == tptp_cnf ||
 (*LastNodeType == tptp_tpi && ThisNodeType != tptp_tpi)) &&
 ThisNodeType != blank_line) {
-        printf("\n");
+        fprintf(OutputHandle,"\n");
     }
 
 //----Expand includes if necessary
@@ -341,7 +341,9 @@ ThisNodeType != blank_line) {
         PrintAnnotatedTSTPNode(OutputHandle,AnnotatedFormula,Options.Format,Options.Pretty);
     }
     *LastNodeType = ThisNodeType;
-    fflush(stdout);
+    if (OutputHandle == stdout) {
+        fflush(OutputHandle);
+    }
 }
 //-------------------------------------------------------------------------------------------------
 unsigned long long GetTimeInMillis() {

--- a/tptp4X.c
+++ b/tptp4X.c
@@ -341,9 +341,7 @@ ThisNodeType != blank_line) {
         PrintAnnotatedTSTPNode(OutputHandle,AnnotatedFormula,Options.Format,Options.Pretty);
     }
     *LastNodeType = ThisNodeType;
-    if (OutputHandle == stdout) {
-        fflush(OutputHandle);
-    }
+    fflush(OutputHandle);
 }
 //-------------------------------------------------------------------------------------------------
 unsigned long long GetTimeInMillis() {


### PR DESCRIPTION
Hi Geoff, thanks for developing this tool! I found a small issue while playing with the pretty-printer.

Suppose we have `1.p` in the working directory that needs to be pretty-printed and its content is
```tptp
fof(  bad_tourism,axiom,(rains| too_hot)    => tourist_trade_declines).
fof(tourism_police,axiom,tourist_trade_declines=>happy_police).
fof(unhappy_police,axiom,  ~ happy_police).
fof(not_too_hot,conjecture,  ~too_hot) .
```

Now run these commands in terminal:
```bash
mkdir out
./tptp4X -dout -ftptp 1.p
cat out/1.tptp
```

You can see that blank lines that should be directed to the output file are printed to terminal, so that the terminal displays
```



1.p -> /some/path/out/1.tptp
```
and the output file only contains
```tptp
fof(bad_tourism,axiom,
    ( ( rains
      | too_hot )
   => tourist_trade_declines ) ).
fof(tourism_police,axiom,
    ( tourist_trade_declines
   => happy_police ) ).
fof(unhappy_police,axiom,
    ~ happy_police ).
fof(not_too_hot,conjecture,
    ~ too_hot ).
```

Compare with the output of
```bash
./tptp4X -ftptp 1.p
```
which is
```tptp
fof(bad_tourism,axiom,
    ( ( rains
      | too_hot )
   => tourist_trade_declines ) ).

fof(tourism_police,axiom,
    ( tourist_trade_declines
   => happy_police ) ).

fof(unhappy_police,axiom,
    ~ happy_police ).

fof(not_too_hot,conjecture,
    ~ too_hot ).
```
---
I implemented an easy fix so that the blank line after every formula is directed to `OutputHandle`, after which `fflush` is called only when `OutputHandle` is actually `stdout`. But I'm not sure if this is what you intended.